### PR TITLE
Move Atomic into the Scrolls module

### DIFF
--- a/lib/scrolls/atomic.rb
+++ b/lib/scrolls/atomic.rb
@@ -1,58 +1,59 @@
-# The result of issues with an update I made to Scrolls. After talking with
-# Fabio Kung about a fix I started work on an atomic object, but he added some
-# fixes to #context without it and then used Headius' atomic gem.
-#
-# The code below is the start and cleanup of my atomic object. It's slim on
-# details and eventually cleaned up around inspiration from Headius' code.
-#
-# LICENSE: Apache 2.0
-#
-# See Headius' atomic gem here:
-# https://github.com/headius/ruby-atomic
-
 require 'thread'
 
-class AtomicObject
-  def initialize(o)
-    @mtx = Mutex.new
-    @o = o
-  end
+module Scrolls
+  # The result of issues with an update I made to Scrolls. After talking with
+  # Fabio Kung about a fix I started work on an atomic object, but he added some
+  # fixes to #context without it and then used Headius' atomic gem.
+  #
+  # The code below is the start and cleanup of my atomic object. It's slim on
+  # details and eventually cleaned up around inspiration from Headius' code.
+  #
+  # LICENSE: Apache 2.0
+  #
+  # See Headius' atomic gem here:
+  # https://github.com/headius/ruby-atomic
+  class AtomicObject
+    def initialize(o)
+      @mtx = Mutex.new
+      @o = o
+    end
 
-  def get
-    @mtx.synchronize { @o }
-  end
+    def get
+      @mtx.synchronize { @o }
+    end
 
-  def set(n)
-    @mtx.synchronize { @o = n }
-  end
+    def set(n)
+      @mtx.synchronize { @o = n }
+    end
 
-  def verify_set(o, n)
-    return false unless @mtx.try_lock
-    begin
-      return false unless @o.equal? o
-      @o = n
-    ensure
-      @mtx.unlock
+    def verify_set(o, n)
+      return false unless @mtx.try_lock
+      begin
+        return false unless @o.equal? o
+        @o = n
+      ensure
+        @mtx.unlock
+      end
     end
   end
-end
 
-class Atomic < AtomicObject
-  def initialize(v=nil)
-    super(v)
-  end
+  class Atomic < AtomicObject
+    def initialize(v=nil)
+      super(v)
+    end
 
-  def value
-    self.get
-  end
+    def value
+      self.get
+    end
 
-  def value=(v)
-    self.set(v)
-    v
-  end
+    def value=(v)
+      self.set(v)
+      v
+    end
 
-  def update
-    true until self.verify_set(o = self.get, n = yield(o))
-    n
+    def update
+      true until self.verify_set(o = self.get, n = yield(o))
+      n
+    end
   end
 end

--- a/test/test_atomic.rb
+++ b/test/test_atomic.rb
@@ -2,22 +2,22 @@ require_relative "test_helper"
 
 class TestAtomic < Test::Unit::TestCase
   def test_construct
-    atomic = Atomic.new
+    atomic = Scrolls::Atomic.new
     assert_equal nil, atomic.value
     
-    atomic = Atomic.new(0)
+    atomic = Scrolls::Atomic.new(0)
     assert_equal 0, atomic.value
   end
   
   def test_value
-    atomic = Atomic.new(0)
+    atomic = Scrolls::Atomic.new(0)
     atomic.value = 1
     
     assert_equal 1, atomic.value
   end
   
   def test_update
-    atomic = Atomic.new(1000)
+    atomic = Scrolls::Atomic.new(1000)
     res = atomic.update {|v| v + 1}
     
     assert_equal 1001, atomic.value
@@ -26,7 +26,7 @@ class TestAtomic < Test::Unit::TestCase
 
   def test_update_retries
     tries = 0
-    atomic = Atomic.new(1000)
+    atomic = Scrolls::Atomic.new(1000)
     atomic.update{|v| tries += 1 ; atomic.value = 1001 ; v + 1}
     assert_equal 2, tries
   end


### PR DESCRIPTION
This allows Scrolls to be used in a project that already uses the Atomic gem.
