### PR TITLE
Remove Timeout::Error as it's a subclass of StandardError

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -71,7 +71,7 @@ module Scrolls
         log(logdata.merge(:at => "start"))
         begin
           res = yield
-        rescue StandardError, Timeout::Error => e
+        rescue StandardError => e
           log(
             :at           => "exception",
             :reraise      => true,


### PR DESCRIPTION
irb(main):008:0> Timeout::Error.superclass.superclass
=> StandardError

Also causes a problem if you haven't required 'timeout' somewhere
