### PR TITLE
Scrolls.context should be restored even when an exception is raised

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -118,6 +118,7 @@ module Scrolls
       old = context
       self.context = old.merge(prefix)
       res = yield if block_given?
+    ensure
       self.context = old
       res
     end

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -72,6 +72,18 @@ class TestScrolls < Test::Unit::TestCase
     assert_equal output, @out.string
   end
 
+  def test_context_after_exception
+    begin
+      Scrolls.context(c: 'c') do
+        raise "Error from inside of context"
+      end
+      fail "Exception did not escape context block"
+    rescue => e
+      Scrolls.log(o: 'o')
+      assert_equal "o=o\n", @out.string
+    end
+  end
+
   def test_default_time_unit
     assert_equal "seconds", Scrolls.time_unit
   end


### PR DESCRIPTION
This is a crucial piece of exception handling, hope you can use it.
