### PR TITLE
Scrolls::Log.log_exception: output full backtrace in normal order

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -101,8 +101,7 @@ module Scrolls
           :exception_id => e.object_id.abs
       ))
       if e.backtrace
-        bt = e.backtrace.reverse
-        bt[0, bt.size-6].each do |line|
+        e.backtrace.each do |line|
           log(logdata.merge(
               :at => "exception",
               :class => e.message,

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -116,7 +116,10 @@ class TestScrolls < Test::Unit::TestCase
     rescue Exception => e
       Scrolls.log_exception({test: "exception"}, e)
     end
-    @out.truncate(27)
-    assert_equal "test=exception at=exception", @out.string
+
+    oneline_backtrace = @out.string.gsub("\n", 'XX')
+
+    assert_match /test=exception at=exception.*test_log_exception.*XX.*minitest/,
+      oneline_backtrace
   end
 end


### PR DESCRIPTION
This caught me by surprise, especially the reversed ordering of the lines.

Hope this comes in handy.
