### PR TITLE
Add support for single nested hashes.

### DIFF
--- a/lib/scrolls/parser.rb
+++ b/lib/scrolls/parser.rb
@@ -14,21 +14,10 @@ module Scrolls
           "#{k}=nil"
         elsif v.is_a?(Time)
           "#{k}=#{v.strftime("%FT%H:%M:%S%z")}"
+        elsif v.is_a?(Hash)
+          v.map { |(nk,nv)| "#{k}.#{nk.to_s}=#{handle_quotes(nv)}" }
         else
-          v = v.to_s
-          has_single_quote = v.index("'")
-          has_double_quote = v.index('"')
-          if v =~ / /
-            if has_single_quote && has_double_quote
-              v = '"' + v.gsub(/\\|"/) { |c| "\\#{c}" } + '"'
-            elsif has_double_quote
-              v = "'" + v.gsub('\\', '\\\\\\') + "'"
-            else
-              v = '"' + v.gsub('\\', '\\\\\\') + '"'
-            end
-          elsif v =~ /=/
-            v = '"' + v + '"'
-          end
+          v = handle_quotes(v)
           "#{k}=#{v}"
         end
       end.compact.join(" ")
@@ -36,17 +25,26 @@ module Scrolls
 
     def parse(data)
       vals = {}
+      nvals = {}
       str = data.dup if data.is_a?(String)
 
       patterns = [
         /([^= ]+)="((?:\\.|[^"\\])*)"/, # key="\"literal\" escaped val"
         /([^= ]+)='((?:\\.|[^'\\])*)'/, # key='\'literal\' escaped val'
+        /([^= ]+)\.([^= ]+)=([^ =]+)/,  # key.group=value
         /([^= ]+)=([^ =]+)/             # key=value
       ]
 
       patterns.each do |pattern|
         str.scan(pattern) do |match|
-          v = match[1]
+          k = match[0]         # Our key will always be our first match
+          if match.length == 3 # If we are parsing a nested value (ie: k.n=v)
+            n = match[1]       # Then our nested key will be our second match
+            v = match[2]       # And our nested value will be our third match
+          else
+            v = match[1]       # Default
+          end
+
           v.gsub!(/\\"/, '"')                # unescape \"
           v.gsub!(/\\\\/, "\\")              # unescape \\
 
@@ -60,7 +58,12 @@ module Scrolls
             v = true
           end
 
-          vals[match[0]] = v
+          if n
+            nvals[n.to_sym] = v
+            vals[k] = nvals
+          else
+            vals[k] = v
+          end
         end
         # sub value, leaving keys in order
         str.gsub!(pattern, "\\1")
@@ -71,6 +74,26 @@ module Scrolls
         h[k.to_sym] = vals[k]
         h
       end
+    end
+
+    private
+
+    def handle_quotes(v)
+      v = v.to_s
+      has_single_quote = v.index("'")
+      has_double_quote = v.index('"')
+      if v =~ / /
+        if has_single_quote && has_double_quote
+          v = '"' + v.gsub(/\\|"/) { |c| "\\#{c}" } + '"'
+        elsif has_double_quote
+          v = "'" + v.gsub('\\', '\\\\\\') + "'"
+        else
+          v = '"' + v.gsub('\\', '\\\\\\') + '"'
+        end
+      elsif v =~ /=/
+        v = '"' + v + '"'
+      end
+      v
     end
   end
 end

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -68,4 +68,10 @@ class TestScrollsParser < Test::Unit::TestCase
     data = { n: nil }
     assert_equal "n=nil", unparse(data)
   end
+
+  def test_nested_hashes
+    data = { t: { n: "v", o: "w" } }
+    assert_equal 't.n=v t.o=w', unparse(data)
+    assert_equal data.inspect, parse(unparse(data)).inspect
+  end
 end


### PR DESCRIPTION
I'm actually curious about what people think of this, is it worth it?

@wuputah opened #25 months ago but at the time I wasn't sure it was useful, however, I've finally hit a point where it would be.

Obviously this is something that could get out of hand, I don't think Scrolls should ever be concerned with hashes nested more than one deep, but a single nested hash actually works out pretty nicely.

I've chosen the '.' as a hash separator for a couple of reasons:
- In general keys should match `\w+`, so using a '_' as @wuputah suggests would become impossible to parse.
- ':' is used in Time formats and should, I think, be left alone with regards to keys.
- The [TOML spec](https://github.com/mojombo/toml#hash) uses '.' for key groups so there is some precedence.

As an explanation here is what this PR gets us:

``` ruby
log_this = {
  "rid"  => "blah-blah-blah",
  "data" => {
    "req_method" => "get",
    "req_path"   => "/emoji"
  }
}
```

Parses to:

```
rid=blah-blah-blah data.req_method=get data.req_path=/emoji
```
