### PR TITLE
Add support for streaming to Syslog

### DIFF
--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -28,7 +28,7 @@ module Scrolls
       Log.global_context
     end
   end
-  
+
   def add_global_context(data)
     Log.add_global_context(data)
   end
@@ -73,13 +73,36 @@ module Scrolls
     Log.log_exception(data, e)
   end
 
+  # Public: Setup a logging facility (default: Syslog::LOG_USER)
+  #
+  # facility - Syslog facility
+  #
+  # Examples
+  #
+  #   Scrolls.facility = Syslog::LOG_LOCAL7
+  #
+  def facility=(f)
+    Log.facility=(f)
+  end
+
+  # Public: Return the Syslog facility
+  #
+  # Examples
+  #
+  #   Scrolls.facility
+  #   => 8
+  #
+  def facility
+    Log.facility
+  end
+
   # Public: Setup a new output (default: STDOUT)
   #
   # out - New output
   #
   # Options
   #
-  #   syslog - Load 'Syslog::Logger'
+  #   syslog - Load 'Scrolls::SyslogLogger'
   #
   # Examples
   #

--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -45,10 +45,18 @@ module Scrolls
       @global_context.update { |previous_data| previous_data.merge(new_data) }
     end
 
+    def facility=(f)
+      @facility = LOG_FACILITY_MAP[f] if f
+    end
+
+    def facility
+      @facility ||= default_log_facility
+    end
+
     def stream=(out=nil)
       @defined = out.nil? ? false : true
       if out == 'syslog'
-        @stream = Scrolls::SyslogLogger.new($0)
+        @stream = Scrolls::SyslogLogger.new($0, facility)
       else
         @stream = sync_stream(out)
       end
@@ -202,5 +210,8 @@ module Scrolls
       end
     end
 
+    def default_log_facility
+      LOG_FACILITY
+    end
   end
 end

--- a/lib/scrolls/syslog.rb
+++ b/lib/scrolls/syslog.rb
@@ -1,13 +1,41 @@
 require 'syslog'
 
 module Scrolls
+
+  LOG_FACILITY = ENV['LOG_FACILITY'] || Syslog::LOG_USER
+  LOG_FACILITY_MAP = {
+    "auth"     => Syslog::LOG_AUTH,
+    "authpriv" => Syslog::LOG_AUTHPRIV,
+    "cron"     => Syslog::LOG_CRON,
+    "daemon"   => Syslog::LOG_DAEMON,
+    "ftp"      => Syslog::LOG_FTP,
+    "kern"     => Syslog::LOG_KERN,
+    "mail"     => Syslog::LOG_MAIL,
+    "news"     => Syslog::LOG_NEWS,
+    "syslog"   => Syslog::LOG_SYSLOG,
+    "user"     => Syslog::LOG_USER,
+    "uucp"     => Syslog::LOG_UUCP,
+    "local0"   => Syslog::LOG_LOCAL0,
+    "local1"   => Syslog::LOG_LOCAL1,
+    "local2"   => Syslog::LOG_LOCAL2,
+    "local3"   => Syslog::LOG_LOCAL3,
+    "local4"   => Syslog::LOG_LOCAL4,
+    "local5"   => Syslog::LOG_LOCAL5,
+    "local6"   => Syslog::LOG_LOCAL6,
+    "local7"   => Syslog::LOG_LOCAL7,
+  }
+
   class SyslogLogger
-    def initialize(ident = 'scrolls')
-      @syslog = Syslog.open(ident)
+    def initialize(ident = 'scrolls', facility = Syslog::LOG_USER)
+      @syslog = Syslog.open(ident, Syslog::LOG_PID|Syslog::LOG_CONS, facility)
     end
 
     def puts(data)
       @syslog.log(Syslog::LOG_INFO, data)
+    end
+
+    def close
+      @syslog.close
     end
   end
 end

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -8,6 +8,9 @@ class TestScrolls < Test::Unit::TestCase
 
   def teardown
     Scrolls.global_context({})
+    # Reset our syslog context
+    Scrolls.facility = Scrolls::LOG_FACILITY
+    Scrolls.stream.close if Scrolls.stream.respond_to?(:close)
   end
 
   # def test_construct
@@ -133,5 +136,15 @@ class TestScrolls < Test::Unit::TestCase
   def test_syslog_integration
     Scrolls.stream = 'syslog'
     assert_equal Scrolls::SyslogLogger, Scrolls.stream.class
+  end
+
+  def test_syslog_facility
+    Scrolls.stream = 'syslog'
+    assert_equal Syslog::LOG_USER, Scrolls.facility
+  end
+
+  def test_setting_syslog_facility
+    Scrolls.facility = "local7"
+    assert_equal Syslog::LOG_LOCAL7, Scrolls.facility
   end
 end


### PR DESCRIPTION
I've kind of wanted this for a while but never really had a need. Inside GitHub we use rails/unicorn/god everywhere. Getting those to work together well, especially in our current transition to Scrolls logging, is quite painful.

Basically, ~~if you are using Ruby 2.0.0~~, you can specify:

``` ruby
Scrolls.stream = 'syslog'
```

Scrolls will send messages to `user.info` in Syslog.

~~I plan to extend this to allow one to specify facility or level.~~

You can now also specify the facility you'd like to send messages to:

``` ruby
Scrolls.facility = "local7"
Scrolls.stream = 'syslog'
```

/cc @imbriaco
