### PR TITLE
Make sure we always open our syslog connection.

### DIFF
--- a/lib/scrolls/syslog.rb
+++ b/lib/scrolls/syslog.rb
@@ -27,15 +27,16 @@ module Scrolls
 
   class SyslogLogger
     def initialize(ident = 'scrolls', facility = Syslog::LOG_USER)
-      @syslog = Syslog.open(ident, Syslog::LOG_PID|Syslog::LOG_CONS, facility)
+      options = Syslog::LOG_PID|Syslog::LOG_CONS
+      begin
+        @syslog = Syslog.open(ident, options, facility)
+      rescue RuntimeError
+        @syslog = Syslog.reopen(ident, options, facility)
+      end
     end
 
     def puts(data)
-      @syslog.log(Syslog::LOG_INFO, data)
-    end
-
-    def close
-      @syslog.close
+      @syslog.log(Syslog::LOG_INFO, data, nil)
     end
   end
 end

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -10,7 +10,6 @@ class TestScrolls < Test::Unit::TestCase
     Scrolls.global_context({})
     # Reset our syslog context
     Scrolls.facility = Scrolls::LOG_FACILITY
-    Scrolls.stream.close if Scrolls.stream.respond_to?(:close)
   end
 
   def test_construct


### PR DESCRIPTION
This should be a bit more resilient when opening the syslog connection. We also pass a nil argument in for our `*format` in `#log`. This solves a very peculiar ArgumentError that popped up for us in production. I have no been unable to reproduce after trying diligently to script out something that might cause this issue.
