### PR TITLE
Fix odd time behavior

### DIFF
--- a/lib/scrolls/parser.rb
+++ b/lib/scrolls/parser.rb
@@ -15,7 +15,7 @@ module Scrolls
         elsif v.nil?
           "#{k}=nil"
         elsif v.is_a?(Time)
-          "#{k}=#{v.iso8601}"
+          "#{k}=\"#{v.iso8601}\""
         else
           v = v.to_s
           has_single_quote = v.index("'")

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -76,7 +76,7 @@ class TestScrollsParser < Test::Unit::TestCase
   def test_unparse_time
     time = Time.new(2012, 06, 19, 16, 02, 35, "+01:00")
     data = { t: time }
-    assert_equal "t=2012-06-19T16:02:35+01:00", unparse(data)
+    assert_equal 't="2012-06-19T16:02:35+01:00"', unparse(data)
   end
 
   def test_parse_time

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -158,7 +158,7 @@ class TestScrolls < Test::Unit::TestCase
     Scrolls.add_timestamp = true
     Scrolls.log(:test => "foo")
     iso8601_regexp = "(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|0[1-9]|[1-2][0-9])T(2[0-3]|[0-1][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[0-1][0-9]):[0-5][0-9])?"
-    assert_match(/^now=#{iso8601_regexp} test=foo$/, @out.string)
+    assert_match(/^now="#{iso8601_regexp}" test=foo$/, @out.string)
   end
 
   def test_logging_strings


### PR DESCRIPTION
With the advent of #48, timestamps in the ISO8601 format (or any value containing a ":") are now quoted. However, Scrolls own behavior of adding a timestamp with `Scrolls.add_timestamp = true` circumvented this behavior. Example:

Given this code (and some debug output in scrolls):

``` ruby
Scrolls.log(:now => Time.now.iso8601, :timestamp => "f")
Scrolls.add_timestamp = true
Scrolls.log(:timestamp => "t")
```

Before this PR:

```
projects/testscrolls : ./test.rb
{:now=>"2014-01-17T00:49:14-05:00", :timestamp=>"f"}
now="2014-01-17T00:49:14-05:00" timestamp=f
{:now=>2014-01-17 05:49:14 UTC, :timestamp=>"t"}
now=2014-01-17T05:49:14Z timestamp=t
```

After the changes here:

```
projects/testscrolls : ./test.rb
{:now=>"2014-01-17T00:50:18-05:00", :timestamp=>"f"}
now="2014-01-17T00:50:18-05:00" timestamp=f
{:now=>2014-01-17 05:50:18 UTC, :timestamp=>"t"}
now="2014-01-17T05:50:18Z" timestamp=t
```
