### PR TITLE
Add Scrolls#level for setting the level programmatically.

### DIFF
--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -18,6 +18,7 @@ module Scrolls
   def init(options)
     stream     = options.fetch(:stream, STDOUT)
     facility   = options.fetch(:facility, Syslog::LOG_USER)
+    level      = options.fetch(:level, Scrolls::Log::LOG_LEVEL)
     time_unit  = options.fetch(:time_unit, "seconds")
     timestamp  = options.fetch(:timestamp, false)
     exceptions = options.fetch(:exceptions, "multi")
@@ -25,6 +26,7 @@ module Scrolls
 
     Log.stream    = stream
     Log.facility  = facility if facility
+    Log.level     = level
     Log.time_unit = time_unit unless time_unit == "seconds"
     Log.add_timestamp = timestamp unless timestamp == false
 
@@ -140,6 +142,13 @@ module Scrolls
   def facility
     Log.facility
   end
+
+  # Public: Adjust the log level (default: Syslog::INFO)
+  def level=(l)
+    Log.level=(l)
+  end
+
+  # Public: Get the current log level we are logging at
 
   # Public: Setup a new output (default: STDOUT)
   #

--- a/lib/scrolls/syslog.rb
+++ b/lib/scrolls/syslog.rb
@@ -26,17 +26,21 @@ module Scrolls
   }
 
   class SyslogLogger
-    def initialize(ident = 'scrolls', facility = Syslog::LOG_USER)
+    def initialize(ident = 'scrolls', facility = Syslog::LOG_USER, level = Syslog::LOG_INFO)
+      @ident = ident
+      @facility = facility
+      @level = level
+
       options = Syslog::LOG_PID|Syslog::LOG_CONS
       if Syslog.opened?
-        @syslog = Syslog.reopen(ident, options, facility)
+        @syslog = Syslog.reopen(@ident, options, @facility)
       else
-        @syslog = Syslog.open(ident, options, facility)
+        @syslog = Syslog.open(@ident, options, @facility)
       end
     end
 
     def puts(data)
-      @syslog.log(Syslog::LOG_INFO, "%s", data)
+      @syslog.log(@level, "%s", data)
     end
 
     def self.opened?

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -27,7 +27,7 @@ class TestScrolls < Test::Unit::TestCase
     global = @out.string.gsub("\n", 'XX')
     assert_match /g=g.*d=d/, global
   end
-  
+
   def test_adding_to_global_context
     Scrolls.global_context(:g => "g")
     Scrolls.add_global_context(:h => "h")
@@ -175,6 +175,14 @@ class TestScrolls < Test::Unit::TestCase
   def test_logging_strings
     Scrolls.log("string")
     assert_equal "log_message=string\n", @out.string
+  end
+
+  def test_setting_logging_level
+    Scrolls.debug(:t => "t")
+    assert_equal "", @out.string
+    Scrolls.level = Syslog::LOG_DEBUG
+    Scrolls.debug(:t => "t")
+    assert_equal "t=t level=debug\n", @out.string
   end
 
   def test_default_logging_levels


### PR DESCRIPTION
This adds `Scrolls#level` for adjusting the logging level in code. `LOG_LEVEL` is also still used and defaults to `Syslog::LOG_INFO`.

/cc @rsanheim
