### PR TITLE
Added colorization to Scrolls logs

### DIFF
--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -235,6 +235,36 @@ module Scrolls
   def single_line_exceptions?
     Log.single_line_exceptions
   end
+  
+  # Public: Set whether logs should be colorized
+  # (default: false)
+  #
+  # Examples
+  #
+  #   Scrolls.enable_colors = true
+  #
+  def enable_colors=(boolean)
+    Log.enable_colors = boolean
+  end
+
+  def colors_enabled?
+    Log.colors_enabled?
+  end
+
+  # Public: Set colors for colorization of logs
+  # (default: {})
+  #
+  # Examples
+  #
+  #   Scrolls.colors = {:default_key => :yellow, :default_value => :green, :custom_key => :blue, :custom_value => :magenta}
+  #
+  def colors=(hash)
+    Log.colors = hash
+  end
+
+  def colors
+    Log.colors
+  end
 
   # Public: Convience method for Logger replacement
   #

--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -93,6 +93,23 @@ module Scrolls
       @single_line_exceptions || false
     end
 
+    def enable_colors=(boolean)
+      @enable_colors = !!boolean
+    end
+
+    def colors_enabled?
+      @enable_colors || false
+    end
+
+    def colors=(colors)
+      @colors = colors
+    end
+    
+    def colors
+      @colors || {}
+    end
+
+
     def log(data, &blk)
       # If we get a string lets bring it into our structure.
       if data.kind_of? String
@@ -110,6 +127,8 @@ module Scrolls
       # ensure that the timestamp comes first in the Hash, and is placed first
       # on the output, which helps with readability.
       logdata = { :now => Time.now.utc }.merge(logdata) if add_timestamp
+      
+      colorize_output(logdata) if colors_enabled?
 
       unless blk
         write(logdata)

--- a/lib/scrolls/utils.rb
+++ b/lib/scrolls/utils.rb
@@ -1,6 +1,7 @@
+require 'rainbow'
+
 module Scrolls
   module Utils
-
     def hashify(d)
       last = d.pop
       return {} unless last
@@ -15,6 +16,46 @@ module Scrolls
         h[i.to_sym] = true
         h
       end
+    end
+
+    def colorize_output(logdata)
+      return logdata if logdata.empty?
+
+      colorized_hash = {}
+      setup_colors
+
+      logdata.each_pair do |k, v| 
+        k, v = colorize(k, v)
+        colorized_hash[k] = v 
+      end
+      logdata.clear.update(colorized_hash)  
+    end
+    
+    def setup_colors
+      @standard_key_color ||= colors.fetch(:default_key, :red)
+      @standard_value_color ||= colors.fetch(:default_value, :blue)
+      @custom_key_color ||= colors.fetch(:custom_key, :red)
+      @custom_value_color ||= colors.fetch(:custom_value, :blue)
+    end
+
+    def colorize(k, v)
+      if scrolls_key?(k) || colors.empty?
+        default_colorize(k, v)
+      else
+        custom_colorize(k, v)
+      end
+    end
+
+    def scrolls_key?(k)
+      [:now, :at, :reraise, :class, :message, :exception_id, :elapsed, "log_message", :site, :level].include?(k)
+    end
+
+    def default_colorize(key, value)
+      return Rainbow(key).send(:color, @standard_key_color), Rainbow(value).send(:color, @standard_value_color)
+    end
+    
+    def custom_colorize(key, value)
+      return Rainbow(key).send(:color, @custom_key_color), Rainbow(value).send(:color, @custom_value_color)
     end
 
   end

--- a/scrolls.gemspec
+++ b/scrolls.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |gem|
   gem.name          = "scrolls"
   gem.require_paths = ["lib"]
   gem.version       = Scrolls::VERSION
+  gem.add_runtime_dependency 'rainbow', '2.0.0'
 end

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -223,5 +223,34 @@ class TestScrolls < Test::Unit::TestCase
     Scrolls.unknown("unknown")
     assert_equal "log_message=unknown\n", @out.string
   end
+  
+end
+
+class TestScrollsColorized < Test::Unit::TestCase
+  def setup
+    @out = StringIO.new
+    Scrolls.init(:stream => @out)
+    Scrolls.enable_colors = true
+  end
+  
+  def teardown
+    Scrolls.global_context({})
+    # Reset our syslog context
+    Scrolls.facility = Scrolls::LOG_FACILITY
+    Scrolls.add_timestamp = false
+  end
+  
+  def test_scrolls_has_enabled_colors
+    assert Scrolls.colors_enabled?
+    Scrolls.log("string")
+    assert_equal "\e[31mlog_message\e[0m=\e[34mstring\e[0m\n", @out.string
+  end
+  
+  def test_scrolls_with_custom_colors
+    assert Scrolls.colors_enabled?
+    Scrolls.colors = {:default_key => :yellow, :default_value => :green, :custom_key => :red, :custom_value => :cyan }
+    Scrolls.log(:t => "t")
+    assert_equal "\e[31mt\e[0m=\e[34mt\e[0m\n", @out.string
+  end
 
 end


### PR DESCRIPTION
Colorization of the logs.

To toggle colorization provide the following to Scrolls

  Scrolls.enable_colors = true
  Scrolls.colors = {:custom_key => :green, :custom_value => :blue}

Updated gem files

New feature relies on the gem Rainbow.
Rainbow: https://github.com/sickill/rainbow
