### PR TITLE
fix puts race condition

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -247,9 +247,9 @@ module Scrolls
         msg = unparse(data)
         mtx.synchronize do
           begin
-            stream.puts(msg)
+            stream.print(msg + "\n")
           rescue NoMethodError => e
-            raise
+            raise e
           end
         end
       end


### PR DESCRIPTION
in Ruby, `puts *args` is basically calling `print *args, "\n"`, which means there is a race condition when printing output in a concurrent process.