### PR TITLE
don’t fail with nil error for an unknown loglevel

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -257,9 +257,19 @@ module Scrolls
 
     def log_level_ok?(level)
       if level
-        LOG_LEVEL_MAP[level.to_s] <= LOG_LEVEL
+        compare_log_level(level)
       else
         true
+      end
+    end
+
+    def compare_log_level(level)
+      if LOG_LEVEL_MAP[level.to_s]
+        LOG_LEVEL_MAP[level.to_s] <= LOG_LEVEL
+      else
+        raise StandardError.new(
+          "unkown log level, please use: (#{LOG_LEVEL_MAP.keys.join(', ')}"
+        )
       end
     end
 


### PR DESCRIPTION
hey,

i just ended up with the following error because is used `warn` as a loglevel. the error message is not very useful. i had to dig into the code. this PR raises a StandardError with an explanation and shows the list of allowed log level.

```
NoMethodError:
  undefined method `<=' for nil:NilClass
 ./vendor/bundle/ruby/2.1.0/gems/scrolls-0.3.8/lib/scrolls/log.rb:260:in `log_level_ok?'
 ./vendor/bundle/ruby/2.1.0/gems/scrolls-0.3.8/lib/scrolls/log.rb:246:in `write'
 ./vendor/bundle/ruby/2.1.0/gems/scrolls-0.3.8/lib/scrolls/log.rb:115:in `log'
 ./vendor/bundle/ruby/2.1.0/gems/scrolls-0.3.8/lib/scrolls.rb:99:in `log'
```

What do you think?

best,
ben
