### PR TITLE
print is atomic instead of mutex so it works in threaded environs

### DIFF
--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -245,13 +245,7 @@ module Scrolls
     def write(data)
       if log_level_ok?(data[:level])
         msg = unparse(data)
-        mtx.synchronize do
-          begin
-            stream.puts(msg)
-          rescue NoMethodError => e
-            raise
-          end
-        end
+        stream.print(msg + "\n")
       end
     end
 


### PR DESCRIPTION
When using multiple threads we are running into a scenario using SideKiq/SideTiq where the mutex in `Scrolls::Log#write` isn't doing what we expect.  Even with the mutex, it is not shared across threads, and in the following example, the two loglines are not being separated out with a newline as we'd expect:

```
2014-09-18T04:57:00.897495+00:00 54.80.127.117 local7.info app[worker.1]: - d.fdd8e8d0-048c-4667-9199-218114219753 sample#app.q.enqueued=0 sample#app.q.processed=1 sample#watchtower.q.failed=0 measure#app.q.latency=02014-09-18T04:57:00.897Z 2 TID-owg6kvhpo INFO: [Sidetiq] Enqueue: Stats (at: 1411016280.0) (last: 1411016220.0)
```

To simplify the case, we can see that `puts` is not atomic:

```
1.9.3-p448 :015 >   10.times { Thread.new { puts "hi" }}
 => 10 
1.9.3-p448 :016 > hihihihi
hi

hihi


hi
hihi
```

A solution is to use `print`, it is atomic and works as expected (even without the mutex):

```
1.9.3-p448 :016 > 10.times { Thread.new { print "hi\n" }}
hi
hi
hi
 => 10 
hi
hi
hi
hi
hi
hi
```

Additionally, removing the `rescue` that was an artifact from an old refactor:
https://github.com/asenchi/scrolls/commit/60e7220341cd02de006991d35934b1bd7f6f3cd2
