### PR TITLE
Introduce abstraction for stream logging

### DIFF
--- a/lib/scrolls/iolog.rb
+++ b/lib/scrolls/iolog.rb
@@ -1,0 +1,12 @@
+module Scrolls
+  class IOLog
+    def initialize(stream)
+      stream.sync = true
+      @stream = stream
+    end
+
+    def log(data)
+      @stream.write("#{data}\n")
+    end
+  end
+end

--- a/lib/scrolls/log.rb
+++ b/lib/scrolls/log.rb
@@ -1,5 +1,6 @@
 require "scrolls/parser"
 require "scrolls/utils"
+require "scrolls/iolog"
 require "scrolls/syslog"
 
 module Scrolls
@@ -231,21 +232,14 @@ module Scrolls
       ((finish - start).to_f * @t)
     end
 
-    def mtx
-      @mtx ||= Mutex.new
-    end
-
-    def sync_stream(out=nil)
-      out = STDOUT if out.nil?
-      s = out
-      s.sync = true
-      s
+    def sync_stream(out = STDOUT)
+      IOLog.new(out)
     end
 
     def write(data)
       if log_level_ok?(data[:level])
         msg = unparse(data)
-        stream.print(msg + "\n")
+        stream.log(msg)
       end
     end
 

--- a/lib/scrolls/syslog.rb
+++ b/lib/scrolls/syslog.rb
@@ -35,7 +35,7 @@ module Scrolls
       end
     end
 
-    def puts(data)
+    def log(data)
       @syslog.log(Syslog::LOG_INFO, "%s", data)
     end
 

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -14,7 +14,7 @@ class TestScrolls < Test::Unit::TestCase
   end
 
   def test_construct
-    assert_equal StringIO, Scrolls.stream.class
+    assert_equal Scrolls::IOLog, Scrolls.stream.class
   end
 
   def test_default_global_context
@@ -130,7 +130,7 @@ class TestScrolls < Test::Unit::TestCase
 
     oneline_backtrace = @out.string.gsub("\n", 'XX')
 
-    assert_match /test=exception at=exception.*test_log_exception.*XX.*minitest/,
+    assert_match /test=exception at=exception.*test_log_exception.*XX/,
       oneline_backtrace
   end
 
@@ -163,6 +163,12 @@ class TestScrolls < Test::Unit::TestCase
     Scrolls.stream = 'syslog'
     Scrolls.facility = 'local7'
     assert_match /facility=184/, Scrolls.stream.inspect
+  end
+
+  def test_logging_message_with_syslog
+    Scrolls.stream = 'syslog'
+    Scrolls.facility = 'local7'
+    Scrolls.log "scrolls test"
   end
 
   def test_add_timestamp


### PR DESCRIPTION
This introduces a wrapper class to put the logic for logging to an IO like object. This is to prevent having to put all the logic in the log.rb class itself based if it's a syslog instance or not.

It updates the tests to account for this and also removes the now unused mutex code.

Fixes the broken syslog logging currently on master, which fails with the following error:

```
private method `print' called for #<Scrolls::SyslogLogger:0x007f50995aa578>
```

Opted for this approach over implementing `print` in the syslog class, since that would mean having to chop off the added newline there since syslog already handles the newline logic. By introducing the new class, this can be moved there to where the newline logic is needed. 