### PR TITLE
Fix merging log data on nested exception

### DIFF
--- a/lib/scrolls/logger.rb
+++ b/lib/scrolls/logger.rb
@@ -140,7 +140,7 @@ module Scrolls
         begin
           res = yield
         rescue StandardError => e
-          logdata.merge({
+          logdata.merge!({
             at:           "exception",
             reraise:      true,
             class:        e.class,

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -90,6 +90,21 @@ class TestScrolls < Minitest::Test
     end
   end
 
+  def test_deeply_nested_context_after_exception
+    Scrolls.log(:o => "o") do
+      begin
+        Scrolls.log(:io => 'io') do
+          raise "Error from inside of nested logging"
+        end
+      rescue
+        Scrolls.log(:o => 'o')
+      end
+    end
+    @out.truncate(124)
+    output = "o=o at=start\nio=io at=start\nio=io at=exception reraise=true class=RuntimeError message=\"Error from inside of nested logging\""
+    assert_equal output, @out.string
+  end
+
   def test_default_time_unit
     assert_equal "seconds", Scrolls.time_unit
   end


### PR DESCRIPTION
This logic was refactored and before the return value of the .merge call was directly used as an argument for the `log()` call. But since that refactor, it was moved to a separate statement but it means that merging it needs to use `merge!`.

Without `merge!` the newly returned hash isn't assigned to any variable and lost, so we lose this in the logging context.