### PR TITLE
Add support for always quoting in double quotes (strict logfmt standard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ exceptions: "single"
 global_context: {}
 syslog_options: Syslog::LOG_PID|Syslog::LOG_CONS
 escape_keys: false
+strict_logfmt: false
 ```
 
 ## Older Versions

--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -15,6 +15,7 @@ module Scrolls
   #   global_context - Immutable context to prepend all messages with
   #   syslog_options - Syslog options (default: Syslog::LOG_PID|Syslog::LOG_CONS)
   #   escape_keys    - Escape chars in keys
+  #   strict_logfmt  - Always use double quotes to quote values
   #
   def init(options={})
     # Set a hint whether #init was called.

--- a/lib/scrolls/logger.rb
+++ b/lib/scrolls/logger.rb
@@ -37,14 +37,15 @@ module Scrolls
     attr_accessor :exceptions, :timestamp
 
     def initialize(options={})
-      @stream       = options.fetch(:stream, STDOUT)
-      @log_facility = options.fetch(:facility, LOG_FACILITY)
-      @time_unit    = options.fetch(:time_unit, "seconds")
-      @timestamp    = options.fetch(:timestamp, false)
-      @exceptions   = options.fetch(:exceptions, "single")
-      @global_ctx   = options.fetch(:global_context, {})
-      @syslog_opts  = options.fetch(:syslog_options, SYSLOG_OPTIONS)
-      @escape_keys  = options.fetch(:escape_keys, false)
+      @stream        = options.fetch(:stream, STDOUT)
+      @log_facility  = options.fetch(:facility, LOG_FACILITY)
+      @time_unit     = options.fetch(:time_unit, "seconds")
+      @timestamp     = options.fetch(:timestamp, false)
+      @exceptions    = options.fetch(:exceptions, "single")
+      @global_ctx    = options.fetch(:global_context, {})
+      @syslog_opts   = options.fetch(:syslog_options, SYSLOG_OPTIONS)
+      @escape_keys   = options.fetch(:escape_keys, false)
+      @strict_logfmt = options.fetch(:strict_logfmt, false)
 
       # Our main entry point to ensure our options are setup properly
       setup!
@@ -76,6 +77,10 @@ module Scrolls
 
     def escape_keys?
       @escape_keys
+    end
+
+    def strict_logfmt?
+      @strict_logfmt
     end
 
     def syslog_options
@@ -309,7 +314,7 @@ module Scrolls
 
     def write(data)
       if log_level_ok?(data[:level])
-        msg = Scrolls::Parser.unparse(data, escape_keys=escape_keys?)
+        msg = Scrolls::Parser.unparse(data, escape_keys=escape_keys?, strict_logfmt=strict_logfmt?)
         @logger.log(msg)
       end
     end

--- a/lib/scrolls/parser.rb
+++ b/lib/scrolls/parser.rb
@@ -4,7 +4,7 @@ module Scrolls
   module Parser
     extend self
 
-    def unparse(data, escape_keys=false)
+    def unparse(data, escape_keys=false, strict_logfmt=false)
       data.map do |(k,v)|
         k = Scrolls::Utils.escape_chars(k) if escape_keys
 
@@ -23,7 +23,7 @@ module Scrolls
           has_single_quote = v.index("'")
           has_double_quote = v.index('"')
           if v =~ /[ =:,]/
-            if has_single_quote && has_double_quote
+            if (has_single_quote || strict_logfmt) && has_double_quote
               v = '"' + v.gsub(/\\|"/) { |c| "\\#{c}" } + '"'
             elsif has_double_quote
               v = "'" + v.gsub('\\', '\\\\\\') + "'"

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -88,6 +88,12 @@ class TestScrollsParser < Minitest::Test
       unparse(data, escape_keys=true)
   end
 
+  def test_unparse_strict_logfmt
+    data = { s: 'echo "hello"' }
+    assert_equal 's="echo \"hello\""', unparse(data, escape_keys=false, strict_logfmt=true)
+    assert_equal data.inspect, parse(unparse(data, escape_keys=false, strict_logfmt=true)).inspect
+  end
+
   def test_parse_time
     time = Time.new(2012, 06, 19, 16, 02, 35, "+01:00")
     string = "t=2012-06-19T16:02:35+01:00"


### PR DESCRIPTION
I want to ingest some logs emitted by scrolls with fluent-bit. Sadly,
its logfmt parser is very strict about following the logfmt standard,
and it does not like values quoted with single quotes. This adds an
option to always quote with double quotes.