### PR TITLE
Update license date/name structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright © Curt Micol <asenchi@asenchi.com> 2012,2013,2014
-Copyright © Heroku 2012
+Copyright (c) 2013-2021 Curt Micol <asenchi@asenchi.com>
+Copyright (c) 2012, Heroku
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Based off the info here: https://choosealicense.com/licenses/mit/

No real changes here, just restructuring the dates and names. Saw this recently and wanted to update to best practice here.