### PR TITLE
Version: v0.9.4

### DIFF
--- a/lib/scrolls/version.rb
+++ b/lib/scrolls/version.rb
@@ -1,3 +1,3 @@
 module Scrolls
-  VERSION = "0.9.4.pre"
+  VERSION = "0.9.4"
 end


### PR DESCRIPTION
- LOG_LEVEL is only applied to hash submissions to the Scrolls module methods (thanks @brphelps)
- Adjust license dates/names to best practices according to https://choosealicense.com/licenses/mit/