### PR TITLE
Make the Syslog log_level adapting behavior configurable, instead of always on.

### DIFF
--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -21,7 +21,6 @@ module Scrolls
   def init(options={})
     # Set a hint whether #init was called.
     @initialized = true
-
     @adapt_severity_for_syslog = options.fetch(:adapt_severity_for_syslog, true)
     @log = Logger.new(options)
   end

--- a/lib/scrolls.rb
+++ b/lib/scrolls.rb
@@ -7,19 +7,22 @@ module Scrolls
   # Public: Initialize a Scrolls logger
   #
   # options - A hash of key/values for configuring Scrolls
-  #   stream         - Stream to output data (default: STDOUT)
-  #   log_facility   - Syslog facility (default: Syslog::LOG_USER)
-  #   time_unit      - Unit of time (default: seconds)
-  #   timestamp      - Prepend logs with a timestamp (default: false)
-  #   exceptions     - Method for outputting exceptions (default: single line)
-  #   global_context - Immutable context to prepend all messages with
-  #   syslog_options - Syslog options (default: Syslog::LOG_PID|Syslog::LOG_CONS)
-  #   escape_keys    - Escape chars in keys
-  #   strict_logfmt  - Always use double quotes to quote values
+  #   stream                    - Stream to output data (default: STDOUT)
+  #   log_facility              - Syslog facility (default: Syslog::LOG_USER)
+  #   time_unit                 - Unit of time (default: seconds)
+  #   timestamp                 - Prepend logs with a timestamp (default: false)
+  #   exceptions                - Method for outputting exceptions (default: single line)
+  #   global_context            - Immutable context to prepend all messages with
+  #   syslog_options            - Syslog options (default: Syslog::LOG_PID|Syslog::LOG_CONS)
+  #   escape_keys               - Escape chars in keys
+  #   strict_logfmt             - Always use double quotes to quote values
+  #   adapt_severity_for_syslog - Downgrade severity one level to match syslog (default: true) per https://docs.ruby-lang.org/en/2.1.0/Syslog/Logger.html
   #
   def init(options={})
     # Set a hint whether #init was called.
     @initialized = true
+
+    @adapt_severity_for_syslog = options.fetch(:adapt_severity_for_syslog, true)
     @log = Logger.new(options)
   end
 
@@ -242,7 +245,7 @@ module Scrolls
   #
   def error(data, &blk)
     data = coalesce_strings_to_hash(data)
-    data = data.merge(:level => "warning") if data.is_a?(Hash)
+    data = data.merge(:level => @adapt_severity_for_syslog ? "warning" : "error") if data.is_a?(Hash)
     @log.log(data, &blk)
   end
 
@@ -261,7 +264,7 @@ module Scrolls
   #
   def fatal(data, &blk)
     data = coalesce_strings_to_hash(data)
-    data = data.merge(:level => "error") if data.is_a?(Hash)
+    data = data.merge(:level => @adapt_severity_for_syslog ? "error" : "critical") if data.is_a?(Hash)
     @log.log(data, &blk)
   end
 
@@ -299,7 +302,7 @@ module Scrolls
   #
   def warn(data, &blk)
     data = coalesce_strings_to_hash(data)
-    data = data.merge(:level => "notice") if data.is_a?(Hash)
+    data = data.merge(:level => @adapt_severity_for_syslog ? "notice" : "warn") if data.is_a?(Hash)
     @log.log(data, &blk)
   end
 

--- a/test/test_scrolls.rb
+++ b/test/test_scrolls.rb
@@ -236,6 +236,24 @@ class TestScrolls < Minitest::Test
     assert_equal "log_message=warn level=notice\n", @out.string
   end
 
+  def test_adapted_log_error
+    Scrolls.init({:stream => @out, :adapt_severity_for_syslog => false })
+    Scrolls.error("error")
+    assert_equal "log_message=error level=error\n", @out.string
+  end
+
+  def test_adapted_log_fatal
+    Scrolls.init({:stream => @out, :adapt_severity_for_syslog => false })
+    Scrolls.fatal("fatal")
+    assert_equal "log_message=fatal level=critical\n", @out.string
+  end
+
+  def test_adapted_log_warn
+    Scrolls.init({:stream => @out, :adapt_severity_for_syslog => false })
+    Scrolls.warn("warn")
+    assert_equal "log_message=warn level=warn\n", @out.string
+  end
+
   def test_sending_string_unknown
     Scrolls.unknown("unknown")
     assert_equal "log_message=unknown level=alert\n", @out.string


### PR DESCRIPTION
Fixes #83 .

Added some tests and made sure we could opt out of the log_level changing behavior if we wanted (while leaving the default behavior "on").