### PR TITLE
Add explicit dependency on syslog gem

### DIFF
--- a/scrolls.gemspec
+++ b/scrolls.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |gem|
   gem.name          = "scrolls"
   gem.require_paths = ["lib"]
   gem.version       = Scrolls::VERSION
+
+  gem.add_dependency "syslog"
 end


### PR DESCRIPTION
Using this gem with Ruby 3.3 logs the following warning:

> lib/scrolls/logger.rb:1: warning: syslog was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add syslog to your Gemfile or gemspec.

This pull request adds an explicit dependency on the syslog gem for forward compatibility.