### PR TITLE
Avoid unused assignment

### DIFF
--- a/lib/scrolls/utils.rb
+++ b/lib/scrolls/utils.rb
@@ -53,9 +53,9 @@ module Scrolls
 
     def self.escape_chars(d)
       if d.is_a?(String) and d =~ ESCAPE_CHAR_PATTERN
-        esc = d.to_s.gsub(ESCAPE_CHAR_PATTERN) {|c| ESCAPE_CHAR[c] }
+        d.to_s.gsub(ESCAPE_CHAR_PATTERN) {|c| ESCAPE_CHAR[c] }
       else
-        esc = d
+        d
       end
     end
 


### PR DESCRIPTION
While I was addressing #92, I noticed another warning:

> lib/scrolls/utils.rb:56: warning: assigned but unused variable - esc

I'm not sure when this first started. I still have Ruby 2.5 installed and that also raises it.

It's not critical but I figured to address it considering I was already in the codebase.
